### PR TITLE
Cleanup repository for CI

### DIFF
--- a/Invio.Extensions.Reflection.sln
+++ b/Invio.Extensions.Reflection.sln
@@ -1,0 +1,56 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26124.0
+MinimumVisualStudioVersion = 15.0.26124.0
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{B46A497E-B346-46D6-9DC0-595C93EE4FC4}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Invio.Extensions.Reflection", "src\Invio.Extensions.Reflection\Invio.Extensions.Reflection.csproj", "{B92CE23F-AB17-4CEF-8499-CA2C5364E95A}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{966D3BFA-0D80-4062-9708-98C95E0DF0C2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Invio.Extensions.Reflection.Tests", "test\Invio.Extensions.Reflection.Tests\Invio.Extensions.Reflection.Tests.csproj", "{A730B94E-104D-4687-B963-B1D66DAFBDC1}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{B92CE23F-AB17-4CEF-8499-CA2C5364E95A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B92CE23F-AB17-4CEF-8499-CA2C5364E95A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B92CE23F-AB17-4CEF-8499-CA2C5364E95A}.Debug|x64.ActiveCfg = Debug|x64
+		{B92CE23F-AB17-4CEF-8499-CA2C5364E95A}.Debug|x64.Build.0 = Debug|x64
+		{B92CE23F-AB17-4CEF-8499-CA2C5364E95A}.Debug|x86.ActiveCfg = Debug|x86
+		{B92CE23F-AB17-4CEF-8499-CA2C5364E95A}.Debug|x86.Build.0 = Debug|x86
+		{B92CE23F-AB17-4CEF-8499-CA2C5364E95A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B92CE23F-AB17-4CEF-8499-CA2C5364E95A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B92CE23F-AB17-4CEF-8499-CA2C5364E95A}.Release|x64.ActiveCfg = Release|x64
+		{B92CE23F-AB17-4CEF-8499-CA2C5364E95A}.Release|x64.Build.0 = Release|x64
+		{B92CE23F-AB17-4CEF-8499-CA2C5364E95A}.Release|x86.ActiveCfg = Release|x86
+		{B92CE23F-AB17-4CEF-8499-CA2C5364E95A}.Release|x86.Build.0 = Release|x86
+		{A730B94E-104D-4687-B963-B1D66DAFBDC1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A730B94E-104D-4687-B963-B1D66DAFBDC1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A730B94E-104D-4687-B963-B1D66DAFBDC1}.Debug|x64.ActiveCfg = Debug|x64
+		{A730B94E-104D-4687-B963-B1D66DAFBDC1}.Debug|x64.Build.0 = Debug|x64
+		{A730B94E-104D-4687-B963-B1D66DAFBDC1}.Debug|x86.ActiveCfg = Debug|x86
+		{A730B94E-104D-4687-B963-B1D66DAFBDC1}.Debug|x86.Build.0 = Debug|x86
+		{A730B94E-104D-4687-B963-B1D66DAFBDC1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A730B94E-104D-4687-B963-B1D66DAFBDC1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A730B94E-104D-4687-B963-B1D66DAFBDC1}.Release|x64.ActiveCfg = Release|x64
+		{A730B94E-104D-4687-B963-B1D66DAFBDC1}.Release|x64.Build.0 = Release|x64
+		{A730B94E-104D-4687-B963-B1D66DAFBDC1}.Release|x86.ActiveCfg = Release|x86
+		{A730B94E-104D-4687-B963-B1D66DAFBDC1}.Release|x86.Build.0 = Release|x86
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{B92CE23F-AB17-4CEF-8499-CA2C5364E95A} = {B46A497E-B346-46D6-9DC0-595C93EE4FC4}
+		{A730B94E-104D-4687-B963-B1D66DAFBDC1} = {966D3BFA-0D80-4062-9708-98C95E0DF0C2}
+	EndGlobalSection
+EndGlobal

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,7 @@ nuget:
 build_script:
 - ps: .\build.ps1
 after_build:
+- ps: .\set-debug-type.ps1
 - ps: .\coverage.ps1
 test: off
 artifacts:

--- a/build.ps1
+++ b/build.ps1
@@ -52,15 +52,12 @@ if(Test-Path .\artifacts) { Remove-Item .\artifacts -Force -Recurse }
 
 EnsurePsbuildInstalled
 
-exec { & dotnet restore .\src\Invio.Extensions.Reflection }
-exec { & dotnet restore .\test\Invio.Extensions.Reflection.Tests }
-
-exec { & dotnet build .\src\Invio.Extensions.Reflection }
-exec { & dotnet build .\test\Invio.Extensions.Reflection.Tests }
+exec { & dotnet restore }
+exec { & dotnet build }
 
 $revision = @{ $true = $env:APPVEYOR_BUILD_NUMBER; $false = 1 }[$env:APPVEYOR_BUILD_NUMBER -ne $NULL];
 $revision = "{0:D4}" -f [convert]::ToInt32($revision, 10)
 
 exec { & dotnet test .\test\Invio.Extensions.Reflection.Tests\Invio.Extensions.Reflection.Tests.csproj -c Release }
 
-exec { & dotnet pack .\src\Invio.Extensions.Reflection -c Release -o ..\..\artifacts }
+exec { & dotnet pack -c Release -o ..\..\artifacts }

--- a/build.sh
+++ b/build.sh
@@ -9,9 +9,8 @@ if [ -d $artifactsFolder ]; then
   rm -R $artifactsFolder
 fi
 
-dotnet restore ./src/Invio.Extensions.Reflection
-dotnet restore ./test/Invio.Extensions.Reflection.Tests
+dotnet restore
 
 dotnet test ./test/Invio.Extensions.Reflection.Tests/Invio.Extensions.Reflection.Tests.csproj -c Release -f netcoreapp1.0
 
-dotnet pack ./src/Invio.Extensions.Reflection -c Release -o ../../artifacts
+dotnet pack -c Release -o ../../artifacts

--- a/set-debug-type.ps1
+++ b/set-debug-type.ps1
@@ -1,0 +1,8 @@
+$projectName = "Invio.Extensions.Reflection"
+
+copy "src\${projectName}\${projectName}.csproj" "src\${projectName}\${projectName}.csproj.bak"
+
+$project = New-Object XML
+$project.Load("${pwd}\src\${projectName}\${projectName}.csproj")
+$project.Project.PropertyGroup.DebugType = "full"
+$project.Save("${pwd}\src\${projectName}\${projectName}.csproj")

--- a/src/Invio.Extensions.Reflection/Invio.Extensions.Reflection.csproj
+++ b/src/Invio.Extensions.Reflection/Invio.Extensions.Reflection.csproj
@@ -5,7 +5,7 @@
     <VersionPrefix>1.0.2</VersionPrefix>
     <Authors>Saqib Rokadia &lt;saqib@invioinc.com&gt;;Brian Caruso &lt;brian@invioinc.com&gt;</Authors>
     <TargetFramework>netstandard1.3</TargetFramework>
-    <DebugType>full</DebugType>
+    <DebugType>portable</DebugType>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Invio.Extensions.Reflection</AssemblyName>
     <PackageId>Invio.Extensions.Reflection</PackageId>

--- a/test/Invio.Extensions.Reflection.Tests/Invio.Extensions.Reflection.Tests.csproj
+++ b/test/Invio.Extensions.Reflection.Tests/Invio.Extensions.Reflection.Tests.csproj
@@ -12,6 +12,7 @@
     <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
       1.1.1
     </RuntimeFrameworkVersion>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
@@ -21,7 +22,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-*" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-    <PackageReference Include="Invio.Xunit" Version="0.1.2" />
+    <PackageReference Include="Invio.Xunit" Version="0.1.3" />
     <PackageReference Include="xunit" Version="2.2.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Closes #24 

Improves `dotnet` CLI developer ergonomics
Improves symbol export via `<DebugType>` of `portable`